### PR TITLE
add minimal build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,31 @@
 # Lovelace Academy: Learn  
 Content for https://learn.lovelace.academy
 
-## Updated on
+## Development
+
+### Install Dependencies
+
+Builds on Ruby 2.7
+
+```bash
+gem install bundler:2.2.17
+bundle install
+```
+
+### Serve Locally
+
+```bash
+bundle exec jekyll serve
+```
+
+## Usage
+
+### Updated on
 
 To show the last modification date, add a `last_modified_at` field on
 the frontmatter with the current date.
 
-## Notification blockquotes
+### Notification blockquotes
 
 If you need to create notification-styled blockquotes, add them like
 this on the post file:


### PR DESCRIPTION
Adding some simple installation instructions to the readme. Would be good to have this for future reference. Restructured readme hierarchy to accommodate this.