### PR TITLE
Customize code tab plugin

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,7 +17,6 @@ gem "minima", "~> 2.5"
 group :jekyll_plugins do
   gem "jekyll-feed", "~> 0.12"
   gem 'jekyll-slugify-categories'
-  gem "jekyll-simple-tab"
   gem 'jekyll-target-blank'
 end
 
@@ -30,4 +29,7 @@ end
 
 # Performance-booster for watching directories on Windows
 gem "wdm", "~> 0.1.1", :platforms => [:mingw, :x64_mingw, :mswin]
+
+# code tabs dependencies
+gem "slim"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -35,9 +35,6 @@ GEM
       sassc (> 2.0.1, < 3.0)
     jekyll-seo-tag (2.7.1)
       jekyll (>= 3.8, < 5.0)
-    jekyll-simple-tab (0.1.6)
-      jekyll (>= 3.0)
-      slim (>= 3.0)
     jekyll-slugify-categories (0.1.1)
       jekyll (~> 4)
     jekyll-target-blank (2.0.0)
@@ -89,10 +86,10 @@ PLATFORMS
 DEPENDENCIES
   jekyll (~> 4.2.0)
   jekyll-feed (~> 0.12)
-  jekyll-simple-tab
   jekyll-slugify-categories
   jekyll-target-blank
   minima (~> 2.5)
+  slim
   tzinfo (~> 1.2)
   tzinfo-data
   wdm (~> 0.1.1)

--- a/_config.yml
+++ b/_config.yml
@@ -72,7 +72,6 @@ menu:
 plugins:
   - jekyll-feed
   - jekyll-slugify-categories
-  - jekyll-simple-tab
   - jekyll-target-blank
 
 sass:

--- a/_plugins/jekyll-simple-tab.rb
+++ b/_plugins/jekyll-simple-tab.rb
@@ -1,0 +1,61 @@
+require 'slim'
+
+DEFAULT_TEMPLATE = 'template.slim'
+
+module Jekyll
+  module Simple
+    module Tab
+      class TabsBlock < Liquid::Block
+        def initialize(tag, args, _)
+          super
+
+          raise SyntaxError.new("#{tag} requires name") if args.empty?
+
+          @tab_name = args.strip
+        end
+
+        def template_path(template_name)
+          dir = File.dirname(__FILE__)
+          File.join(dir, template_name.to_s)
+        end
+
+        def render(context)
+          @environment = context.environments.first
+          super
+
+          templateFilePath = template_path(DEFAULT_TEMPLATE)
+          template = Slim::Template.new(templateFilePath)
+          template.render(self)
+        end
+      end
+
+      class TabBlock < Liquid::Block
+        def initialize(tag, args, _)
+          super
+
+          @tabs_group, @tab = split_params(args.strip)
+          raise SyntaxError.new("Block #{tag} requires tabs name") if @tabs_group.empty? || @tab.empty?
+        end
+
+        def render(context)
+          site = context.registers[:site]
+          converter = site.find_converter_instance(::Jekyll::Converters::Markdown)
+          content = converter.convert(super)
+
+          environment = context.environments.first
+          environment["tabs-#{@tabs_group}"] ||= {}
+          environment["tabs-#{@tabs_group}"][@tab] = content
+        end
+
+        private
+
+        def split_params(params)
+          params.split('#')
+        end
+      end
+    end
+  end
+end
+
+Liquid::Template.register_tag('tabs', Jekyll::Simple::Tab::TabsBlock)
+Liquid::Template.register_tag('tab', Jekyll::Simple::Tab::TabBlock)

--- a/_plugins/template.slim
+++ b/_plugins/template.slim
@@ -2,14 +2,14 @@ ul.nav.nav-tabs.mb-3 data-tab="#{@tab_name}" role="tablist"
   - @environment["tabs-#{@tab_name}"].each_with_index do |(key, _), index|
     li.nav-item
       - if index == 0
-        a.nav-link.active id="#{key}-tab" data-toggle="tab" href="##{key}" role="tab" aria-controls="#{key}" aria-selected="true"= key
+        a.nav-link.active id="#{@tab_name}#{index}-tab" data-toggle="tab" href="##{@tab_name}#{index}" role="tab" aria-controls="#{@tab_name}#{index}" aria-selected="true"= key
       - else
-        a.nav-link id="#{key}-tab" data-toggle="tab" href="##{key}" role="tab" aria-controls="#{key}" aria-selected="false"= key
+        a.nav-link id="#{@tab_name}#{index}-tab" data-toggle="tab" href="##{@tab_name}#{index}" role="tab" aria-controls="#{@tab_name}#{index}" aria-selected="false"= key
 .tab-content id="#{@tab_name}Content"
   - @environment["tabs-#{@tab_name}"].each_with_index do |(key, value), index|
     - if index == 0
-      .tab-pane.fade.show.active id="#{key}" role="tabpanel" aria-labelledby="#{key}-tab"
+      .tab-pane.fade.show.active id="#{@tab_name}#{index}" role="tabpanel" aria-labelledby="#{@tab_name}#{index}-tab"
         == value
     - else
-      .tab-pane.fade id="#{key}" role="tabpanel" aria-labelledby="#{key}-tab"
+      .tab-pane.fade id="#{@tab_name}#{index}" role="tabpanel" aria-labelledby="#{@tab_name}#{index}-tab"
         == value

--- a/_plugins/template.slim
+++ b/_plugins/template.slim
@@ -1,0 +1,15 @@
+ul.nav.nav-tabs.mb-3 data-tab="#{@tab_name}" role="tablist"
+  - @environment["tabs-#{@tab_name}"].each_with_index do |(key, _), index|
+    li.nav-item
+      - if index == 0
+        a.nav-link.active id="#{key}-tab" data-toggle="tab" href="##{key}" role="tab" aria-controls="#{key}" aria-selected="true"= key
+      - else
+        a.nav-link id="#{key}-tab" data-toggle="tab" href="##{key}" role="tab" aria-controls="#{key}" aria-selected="false"= key
+.tab-content id="#{@tab_name}Content"
+  - @environment["tabs-#{@tab_name}"].each_with_index do |(key, value), index|
+    - if index == 0
+      .tab-pane.fade.show.active id="#{key}" role="tabpanel" aria-labelledby="#{key}-tab"
+        == value
+    - else
+      .tab-pane.fade id="#{key}" role="tabpanel" aria-labelledby="#{key}-tab"
+        == value


### PR DESCRIPTION
After a second review of the options, the jekyll-simple-tab plugin seemed to still be the best, as it only required a change to the template. The modified plugin has been reinstalled to the local _plugin folder, with dependencies added to the gemfile